### PR TITLE
Bump `terraform-aws-codebuild` version to `0.5.2`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 module "build" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.5.1"
+  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.5.2"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"


### PR DESCRIPTION
## What

* Updated `terraform-aws-codebuild` version


## Why

* Version `0.5.2` is the latest version with bug fixes
