### PR TITLE
Change `poll_source_changes` default type from boolean to string

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,8 +46,11 @@ variable "buildspec" {
   description = "Optional buildspec declaration to use for building the project"
 }
 
+# https://www.terraform.io/docs/configuration/variables.html
+# It is recommended you avoid using boolean values and use explicit strings
 variable "poll_source_changes" {
-  default = true
+  type = "string"
+  default = "true"
   description = "Periodically check the location of your source content and run the pipeline if changes are detected"
 }
 


### PR DESCRIPTION
## What

* Changed `poll_source_changes` default type from boolean to string


## Why

* The boolean default value `true` did not work as expected and was converted to `false` in
```
      configuration {
        OAuthToken           = "${var.github_oauth_token}"
        Owner                = "${var.repo_owner}"
        Repo                 = "${var.repo_name}"
        Branch               = "${var.branch}"
        PollForSourceChanges = "${var.poll_source_changes}"
      }
```

* The module did not poll the GitHub repo for changes

* Terraform recommendeds using explicit strings instead of boolean values

> Although it appears Terraform supports boolean types, they are instead silently converted to string types. The implications of this are subtle and should be completely understood if you plan on using boolean values. It is instead recommended you avoid using boolean values for now and use explicit strings. A future version of Terraform will properly support booleans and using the current behavior could result in backwards-incompatibilities in the future.


## References

* https://www.terraform.io/docs/configuration/variables.html
