### PR TITLE
Bump `terraform-aws-codebuild` version to `0.5.3`. Change ENV var default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,26 +153,26 @@ CMD [ "npm", "start" ]
 
 ## Input
 
-| Name                | Default                      | Description                                                                                                                                                     |
-|:--------------------|:----------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| namespace           | global                       | Namespace                                                                                                                                                       |
-| stage               | default                      | Stage                                                                                                                                                           |
-| name                | app                          | Name                                                                                                                                                            |
-| enabled             | true                         | Enable ``CodePipeline`` creation                                                                                                                                |
-| app                 | ""                           | (Optional) Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created                 |
-| env                 | ""                           | (Optional) Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created                 |
-| github_oauth_token  | ""                           | (Optional) GitHub Oauth Token with permissions to access private repositories                                                                                   |
-| repo_owner          | ""                           | GitHub Organization or Person name                                                                                                                              |
-| repo_name           | ""                           | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured)                                                         |
-| branch              | ""                           | Branch of the GitHub repository, _e.g._ ``master``                                                                                                              |
-| build_image         | aws/codebuild/docker:1.12.1  | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                               |
-| build_compute_type  | BUILD_GENERAL1_SMALL         | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                              |
-| buildspec           | ""                           | (Optional) `buildspec` declaration to use for building the project. http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html                   |
-| privileged_mode     | ""                           | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images            |
-| aws_region          | ""                           | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable ``$AWS_REGION`` when building Docker images                                         |
-| aws_account_id      | ""                           | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable ``$AWS_ACCOUNT_ID`` when building Docker images                                                     |
-| image_repo_name     | ""                           | (Optional) ECR repository name to store the Docker image built by the module. Used as `CodeBuild` ENV variable ``$IMAGE_REPO_NAME`` when building Docker images |
-| image_tag           | ""                           | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable ``$IMAGE_TAG`` when building Docker images                 |
+| Name                | Default                        | Description                                                                                                                                                     |
+|:--------------------|:------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| namespace           | "global"                       | Namespace                                                                                                                                                       |
+| stage               | "default"                      | Stage                                                                                                                                                           |
+| name                | "app"                          | Name                                                                                                                                                            |
+| enabled             | "true"                         | Enable ``CodePipeline`` creation                                                                                                                                |
+| app                 | ""                             | (Optional) Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created                 |
+| env                 | ""                             | (Optional) Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created                 |
+| github_oauth_token  | ""                             | (Optional) GitHub Oauth Token with permissions to access private repositories                                                                                   |
+| repo_owner          | ""                             | GitHub Organization or Person name                                                                                                                              |
+| repo_name           | ""                             | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured)                                                         |
+| branch              | ""                             | Branch of the GitHub repository, _e.g._ ``master``                                                                                                              |
+| build_image         | "aws/codebuild/docker:1.12.1"  | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                               |
+| build_compute_type  | "BUILD_GENERAL1_SMALL"         | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                              |
+| buildspec           | ""                             | (Optional) `buildspec` declaration to use for building the project. http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html                   |
+| privileged_mode     | ""                             | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images            |
+| aws_region          | ""                             | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable ``$AWS_REGION`` when building Docker images                                         |
+| aws_account_id      | ""                             | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable ``$AWS_ACCOUNT_ID`` when building Docker images                                                     |
+| image_repo_name     | "UNSET"                        | (Optional) ECR repository name to store the Docker image built by the module. Used as `CodeBuild` ENV variable ``$IMAGE_REPO_NAME`` when building Docker images |
+| image_tag           | "latest"                       | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable ``$IMAGE_TAG`` when building Docker images                 |
 
 
 ## License

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 module "build" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.5.2"
+  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.5.3"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -49,8 +49,8 @@ variable "buildspec" {
 # https://www.terraform.io/docs/configuration/variables.html
 # It is recommended you avoid using boolean values and use explicit strings
 variable "poll_source_changes" {
-  type = "string"
-  default = "true"
+  type        = "string"
+  default     = "true"
   description = "Periodically check the location of your source content and run the pipeline if changes are detected"
 }
 
@@ -88,12 +88,12 @@ variable "aws_account_id" {
 
 variable "image_repo_name" {
   type        = "string"
-  default     = ""
+  default     = "UNSET"
   description = "(Optional) ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_tag" {
   type        = "string"
-  default     = ""
+  default     = "latest"
   description = "(Optional) Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }


### PR DESCRIPTION
## What

* Bump `terraform-aws-codebuild` version to `0.5.3`
* Add default values to `ENV` vars


## Why

* Latest `terraform-aws-codebuild` version with bug fixes
* `CodeBuild` throws errors if any provided `ENV` var is emtpty
