### PR TITLE
Bump `terraform-aws-codebuild` version to `0.6.2`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 module "build" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.6.1"
+  source             = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.6.2"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"


### PR DESCRIPTION
## what
* Bumped `terraform-aws-codebuild` version to `0.6.2`

## why
* It adds `STAGE` environment variable for tagging Docker images in ECR
