### PR TITLE
Removed unused OAuthToken from source_build

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,7 +264,6 @@ resource "aws_codepipeline" "source_build" {
       output_artifacts = ["code"]
 
       configuration {
-        OAuthToken           = "${var.github_oauth_token}"
         Owner                = "${var.repo_owner}"
         Repo                 = "${var.repo_name}"
         Branch               = "${var.branch}"


### PR DESCRIPTION
## what
* Drop `OAuthToken`

## why
* It looks like `OAuthToken` is only applicable to `source_build_deploy`, so when it is passed to source_build, Terraform detects changes each time because the value is not persisted.
