### PR TITLE
Support AWS v2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 data "aws_caller_identity" "default" {}
 
-data "aws_region" "default" {
-}
+data "aws_region" "default" {}
 
 # Define composite variables for resources
 module "label" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 data "aws_caller_identity" "default" {}
 
 data "aws_region" "default" {
-  current = true
 }
 
 # Define composite variables for resources


### PR DESCRIPTION
# What

Remove `current` argument

## Why

https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#current-argument-removal