### PR TITLE
fix: remove "current" argument from aws_region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,6 @@
 data "aws_caller_identity" "default" {}
 
-data "aws_region" "default" {
-  current = true
-}
+data "aws_region" "default" {}
 
 # Define composite variables for resources
 module "label" {


### PR DESCRIPTION
Fixes `data.aws_region.default: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled` in aws provider versions 2.x.x

https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#data-source-aws_region