### PR TITLE
Fix counts. Add `enabled` flag. Use dynamic block for Deploy stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Available targets:
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
+| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
+| aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | branch | Branch of the GitHub repository, _e.g._ `master` | string | - | yes |
 | build_compute_type | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` | string | `BUILD_GENERAL1_SMALL` | no |
 | build_image | Docker image for build environment, _e.g._ `aws/codebuild/standard:2.0` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0` | string | `aws/codebuild/standard:2.0` | no |
@@ -234,14 +235,13 @@ Available targets:
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
+| github_oauth_token | GitHub Oauth Token | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | poll_source_changes | Periodically check the location of your source content and run the pipeline if changes are detected | bool | `true` | no |
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | bool | `false` | no |
-| region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | repo_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | string | - | yes |
 | repo_owner | GitHub Organization or Person name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| app | Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
@@ -232,8 +231,9 @@ Available targets:
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codebuild_cache_bucket_suffix_enabled | The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value | bool | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| elastic_beanstalk_application_name | Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
+| elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
-| env | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
 | github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
@@ -385,11 +385,11 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
 
 
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Available targets:
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
+| force_destroy | Force destroy the CI/CD S3 bucket even if it's not empty | bool | `false` | no |
 | github_oauth_token | GitHub Oauth Token | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
-| aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | branch | Branch of the GitHub repository, _e.g._ `master` | string | - | yes |
 | build_compute_type | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` | string | `BUILD_GENERAL1_SMALL` | no |
 | build_image | Docker image for build environment, _e.g._ `aws/codebuild/standard:2.0` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0` | string | `aws/codebuild/standard:2.0` | no |
@@ -242,6 +241,7 @@ Available targets:
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | poll_source_changes | Periodically check the location of your source content and run the pipeline if changes are detected | bool | `true` | no |
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | bool | `false` | no |
+| region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | repo_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | string | - | yes |
 | repo_owner | GitHub Organization or Person name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,7 +15,7 @@
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
+| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,6 @@
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
-| aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | branch | Branch of the GitHub repository, _e.g._ `master` | string | - | yes |
 | build_compute_type | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` | string | `BUILD_GENERAL1_SMALL` | no |
 | build_image | Docker image for build environment, _e.g._ `aws/codebuild/standard:2.0` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0` | string | `aws/codebuild/standard:2.0` | no |
@@ -22,6 +21,7 @@
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | poll_source_changes | Periodically check the location of your source content and run the pipeline if changes are detected | bool | `true` | no |
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | bool | `false` | no |
+| region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | repo_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | string | - | yes |
 | repo_owner | GitHub Organization or Person name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,7 @@
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
+| force_destroy | Force destroy the CI/CD S3 bucket even if it's not empty | bool | `false` | no |
 | github_oauth_token | GitHub Oauth Token | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
+| aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | branch | Branch of the GitHub repository, _e.g._ `master` | string | - | yes |
 | build_compute_type | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` | string | `BUILD_GENERAL1_SMALL` | no |
 | build_image | Docker image for build environment, _e.g._ `aws/codebuild/standard:2.0` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0` | string | `aws/codebuild/standard:2.0` | no |
@@ -14,14 +15,13 @@
 | elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
+| github_oauth_token | GitHub Oauth Token | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | poll_source_changes | Periodically check the location of your source content and run the pipeline if changes are detected | bool | `true` | no |
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | bool | `false` | no |
-| region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | repo_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | string | - | yes |
 | repo_owner | GitHub Organization or Person name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,7 +2,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| app | Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | aws_account_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
 | aws_region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `` | no |
@@ -12,8 +11,9 @@
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codebuild_cache_bucket_suffix_enabled | The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value | bool | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| elastic_beanstalk_application_name | Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
+| elastic_beanstalk_environment_name | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | enabled | Enable ``CodePipeline`` creation | bool | `true` | no |
-| env | Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created | string | `` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | object | `<list>` | no |
 | github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -4,7 +4,7 @@ namespace = "eg"
 
 stage = "test"
 
-name = "cicd-test"
+name = "cicd-build"
 
 github_oauth_token = "test"
 
@@ -17,6 +17,8 @@ branch = "master"
 poll_source_changes = false
 
 codebuild_cache_bucket_suffix_enabled = false
+
+force_destroy = true
 
 environment_variables = [
   {

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -4,7 +4,7 @@ namespace = "eg"
 
 stage = "test"
 
-name = "cicd-build"
+name = "cicd"
 
 github_oauth_token = "test"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,7 +6,7 @@ stage = "test"
 
 name = "cicd-test"
 
-github_oauth_token = ""
+github_oauth_token = "test"
 
 repo_owner = "cloudposse"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,7 +6,7 @@ stage = "test"
 
 name = "cicd-test"
 
-github_oauth_token = "test"
+github_oauth_token = ""
 
 repo_owner = "cloudposse"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,6 +7,7 @@ module "cicd" {
   namespace                             = var.namespace
   stage                                 = var.stage
   name                                  = var.name
+  region                                = var.region
   github_oauth_token                    = var.github_oauth_token
   repo_owner                            = var.repo_owner
   repo_name                             = var.repo_name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,4 +15,5 @@ module "cicd" {
   poll_source_changes                   = var.poll_source_changes
   environment_variables                 = var.environment_variables
   codebuild_cache_bucket_suffix_enabled = var.codebuild_cache_bucket_suffix_enabled
+  force_destroy                         = var.force_destroy
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -21,6 +21,7 @@ variable "name" {
 variable "github_oauth_token" {
   type        = string
   description = "GitHub Oauth Token with permissions to access private repositories"
+  default     = ""
 }
 
 variable "repo_owner" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -20,8 +20,7 @@ variable "name" {
 
 variable "github_oauth_token" {
   type        = string
-  description = "GitHub Oauth Token with permissions to access private repositories"
-  default     = ""
+  description = "GitHub Oauth Token"
 }
 
 variable "repo_owner" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -63,3 +63,8 @@ variable "codebuild_cache_bucket_suffix_enabled" {
   type        = bool
   description = "The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value"
 }
+
+variable "force_destroy" {
+  type        = bool
+  description = "Force destroy the CI/CD S3 bucket even if it's not empty"
+}

--- a/main.tf
+++ b/main.tf
@@ -206,20 +206,42 @@ resource "aws_codepipeline" "default" {
   stage {
     name = "Source"
 
-    action {
-      name             = "Source"
-      category         = "Source"
-      owner            = "ThirdParty"
-      provider         = "GitHub"
-      version          = "1"
-      output_artifacts = ["code"]
+    dynamic "action" {
+      for_each = var.github_oauth_token != "" ? ["true"] : []
+      content {
+        name             = "Source"
+        category         = "Source"
+        owner            = "ThirdParty"
+        provider         = "GitHub"
+        version          = "1"
+        output_artifacts = ["code"]
 
-      configuration = {
-        OAuthToken           = var.github_oauth_token
-        Owner                = var.repo_owner
-        Repo                 = var.repo_name
-        Branch               = var.branch
-        PollForSourceChanges = var.poll_source_changes
+        configuration = {
+          OAuthToken           = var.github_oauth_token
+          Owner                = var.repo_owner
+          Repo                 = var.repo_name
+          Branch               = var.branch
+          PollForSourceChanges = var.poll_source_changes
+        }
+      }
+    }
+
+    dynamic "action" {
+      for_each = var.github_oauth_token == "" ? ["true"] : []
+      content {
+        name             = "Source"
+        category         = "Source"
+        owner            = "ThirdParty"
+        provider         = "GitHub"
+        version          = "1"
+        output_artifacts = ["code"]
+
+        configuration = {
+          Owner                = var.repo_owner
+          Repo                 = var.repo_name
+          Branch               = var.branch
+          PollForSourceChanges = var.poll_source_changes
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,11 @@ module "label" {
 }
 
 resource "aws_s3_bucket" "default" {
-  count  = var.enabled ? 1 : 0
-  bucket = module.label.id
-  acl    = "private"
-  tags   = module.label.tags
+  count         = var.enabled ? 1 : 0
+  bucket        = module.label.id
+  acl           = "private"
+  force_destroy = var.force_destroy
+  tags          = module.label.tags
 }
 
 resource "aws_iam_role" "default" {

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ module "codebuild" {
   attributes                  = concat(var.attributes, ["build"])
   tags                        = var.tags
   privileged_mode             = var.privileged_mode
-  aws_region                  = var.region != "" ? var.region : data.aws_region.default.name
+  aws_region                  = var.aws_region != "" ? var.aws_region : data.aws_region.default.name
   aws_account_id              = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
   image_repo_name             = var.image_repo_name
   image_tag                   = var.image_tag
@@ -206,42 +206,20 @@ resource "aws_codepipeline" "default" {
   stage {
     name = "Source"
 
-    dynamic "action" {
-      for_each = var.github_oauth_token != "" ? ["true"] : []
-      content {
-        name             = "Source"
-        category         = "Source"
-        owner            = "ThirdParty"
-        provider         = "GitHub"
-        version          = "1"
-        output_artifacts = ["code"]
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["code"]
 
-        configuration = {
-          OAuthToken           = var.github_oauth_token
-          Owner                = var.repo_owner
-          Repo                 = var.repo_name
-          Branch               = var.branch
-          PollForSourceChanges = var.poll_source_changes
-        }
-      }
-    }
-
-    dynamic "action" {
-      for_each = var.github_oauth_token == "" ? ["true"] : []
-      content {
-        name             = "Source"
-        category         = "Source"
-        owner            = "ThirdParty"
-        provider         = "GitHub"
-        version          = "1"
-        output_artifacts = ["code"]
-
-        configuration = {
-          Owner                = var.repo_owner
-          Repo                 = var.repo_name
-          Branch               = var.branch
-          PollForSourceChanges = var.poll_source_changes
-        }
+      configuration = {
+        OAuthToken           = var.github_oauth_token
+        Owner                = var.repo_owner
+        Repo                 = var.repo_name
+        Branch               = var.branch
+        PollForSourceChanges = var.poll_source_changes
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -16,17 +16,21 @@ module "label" {
 }
 
 resource "aws_s3_bucket" "default" {
+  count  = var.enabled ? 1 : 0
   bucket = module.label.id
   acl    = "private"
   tags   = module.label.tags
 }
 
 resource "aws_iam_role" "default" {
+  count              = var.enabled ? 1 : 0
   name               = module.label.id
-  assume_role_policy = data.aws_iam_policy_document.assume.json
+  assume_role_policy = join("", data.aws_iam_policy_document.assume.*.json)
 }
 
 data "aws_iam_policy_document" "assume" {
+  count = var.enabled ? 1 : 0
+
   statement {
     sid = ""
 
@@ -44,16 +48,20 @@ data "aws_iam_policy_document" "assume" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  role       = aws_iam_role.default.id
-  policy_arn = aws_iam_policy.default.arn
+  count      = var.enabled ? 1 : 0
+  role       = join("", aws_iam_role.default.*.id)
+  policy_arn = join("", aws_iam_policy.default.*.arn)
 }
 
 resource "aws_iam_policy" "default" {
+  count  = var.enabled ? 1 : 0
   name   = module.label.id
-  policy = data.aws_iam_policy_document.default.json
+  policy = join("", data.aws_iam_policy_document.default.*.json)
 }
 
 data "aws_iam_policy_document" "default" {
+  count = var.enabled ? 1 : 0
+
   statement {
     sid = ""
 
@@ -79,16 +87,20 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "s3" {
-  role       = aws_iam_role.default.id
-  policy_arn = aws_iam_policy.s3.arn
+  count      = var.enabled ? 1 : 0
+  role       = join("", aws_iam_role.default.*.id)
+  policy_arn = join("", aws_iam_policy.s3.*.arn)
 }
 
 resource "aws_iam_policy" "s3" {
+  count  = var.enabled ? 1 : 0
   name   = "${module.label.id}-s3"
-  policy = data.aws_iam_policy_document.s3.json
+  policy = join("", data.aws_iam_policy_document.s3.*.json)
 }
 
 data "aws_iam_policy_document" "s3" {
+  count = var.enabled ? 1 : 0
+
   statement {
     sid = ""
 
@@ -100,8 +112,8 @@ data "aws_iam_policy_document" "s3" {
     ]
 
     resources = [
-      aws_s3_bucket.default.arn,
-      "${aws_s3_bucket.default.arn}/*",
+      join("", aws_s3_bucket.default.*.arn),
+      "${join("", aws_s3_bucket.default.*.arn)}/*",
       "arn:aws:s3:::elasticbeanstalk*"
     ]
 
@@ -110,16 +122,20 @@ data "aws_iam_policy_document" "s3" {
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild" {
-  role       = aws_iam_role.default.id
-  policy_arn = aws_iam_policy.codebuild.arn
+  count      = var.enabled ? 1 : 0
+  role       = join("", aws_iam_role.default.*.id)
+  policy_arn = join("", aws_iam_policy.codebuild.*.arn)
 }
 
 resource "aws_iam_policy" "codebuild" {
+  count  = var.enabled ? 1 : 0
   name   = "${module.label.id}-codebuild"
-  policy = data.aws_iam_policy_document.codebuild.json
+  policy = join("", data.aws_iam_policy_document.codebuild.*.json)
 }
 
 data "aws_iam_policy_document" "codebuild" {
+  count = var.enabled ? 1 : 0
+
   statement {
     sid = ""
 
@@ -134,6 +150,7 @@ data "aws_iam_policy_document" "codebuild" {
 
 module "codebuild" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.17.0"
+  enabled                     = var.enabled
   namespace                   = var.namespace
   name                        = var.name
   stage                       = var.stage
@@ -154,8 +171,9 @@ module "codebuild" {
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {
+  count      = var.enabled ? 1 : 0
   role       = module.codebuild.role_id
-  policy_arn = aws_iam_policy.s3.arn
+  policy_arn = join("", aws_iam_policy.s3.*.arn)
 }
 
 # Only one of the `aws_codepipeline` resources below will be created:
@@ -174,14 +192,14 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 
 # 1. GitHub -> ECR (Docker image)
 
-resource "aws_codepipeline" "source_build_deploy" {
+resource "aws_codepipeline" "default" {
   # Elastic Beanstalk application name and environment name are specified
-  count    = var.enabled && var.elastic_beanstalk_application_name != "" && var.elastic_beanstalk_environment_name != "" ? 1 : 0
+  count    = var.enabled ? 1 : 0
   name     = module.label.id
-  role_arn = aws_iam_role.default.arn
+  role_arn = join("", aws_iam_role.default.*.arn)
 
   artifact_store {
-    location = aws_s3_bucket.default.bucket
+    location = join("", aws_s3_bucket.default.*.bucket)
     type     = "S3"
   }
 
@@ -225,71 +243,23 @@ resource "aws_codepipeline" "source_build_deploy" {
     }
   }
 
-  stage {
-    name = "Deploy"
+  dynamic "stage" {
+    for_each = var.elastic_beanstalk_application_name != "" && var.elastic_beanstalk_environment_name != "" ? ["true"] : []
+    content {
+      name = "Deploy"
 
-    action {
-      name            = "Deploy"
-      category        = "Deploy"
-      owner           = "AWS"
-      provider        = "ElasticBeanstalk"
-      input_artifacts = ["package"]
-      version         = "1"
+      action {
+        name            = "Deploy"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "ElasticBeanstalk"
+        input_artifacts = ["package"]
+        version         = "1"
 
-      configuration = {
-        ApplicationName = var.elastic_beanstalk_application_name
-        EnvironmentName = var.elastic_beanstalk_environment_name
-      }
-    }
-  }
-}
-
-resource "aws_codepipeline" "source_build" {
-  count    = var.enabled && (var.elastic_beanstalk_application_name == "" || var.elastic_beanstalk_environment_name == "") ? 1 : 0
-  name     = module.label.id
-  role_arn = aws_iam_role.default.arn
-
-  artifact_store {
-    location = aws_s3_bucket.default.bucket
-    type     = "S3"
-  }
-
-  stage {
-    name = "Source"
-
-    action {
-      name             = "Source"
-      category         = "Source"
-      owner            = "ThirdParty"
-      provider         = "GitHub"
-      version          = "1"
-      output_artifacts = ["code"]
-
-      configuration = {
-        OAuthToken           = var.github_oauth_token
-        Owner                = var.repo_owner
-        Repo                 = var.repo_name
-        Branch               = var.branch
-        PollForSourceChanges = var.poll_source_changes
-      }
-    }
-  }
-
-  stage {
-    name = "Build"
-
-    action {
-      name     = "Build"
-      category = "Build"
-      owner    = "AWS"
-      provider = "CodeBuild"
-      version  = "1"
-
-      input_artifacts  = ["code"]
-      output_artifacts = ["package"]
-
-      configuration = {
-        ProjectName = module.codebuild.project_name
+        configuration = {
+          ApplicationName = var.elastic_beanstalk_application_name
+          EnvironmentName = var.elastic_beanstalk_environment_name
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ module "codebuild" {
   attributes                  = concat(var.attributes, ["build"])
   tags                        = var.tags
   privileged_mode             = var.privileged_mode
-  aws_region                  = var.aws_region != "" ? var.aws_region : data.aws_region.default.name
+  aws_region                  = var.region != "" ? var.region : data.aws_region.default.name
   aws_account_id              = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
   image_repo_name             = var.image_repo_name
   image_tag                   = var.image_tag

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,10 +35,10 @@ output "codebuild_badge_url" {
 
 output "codepipeline_id" {
   description = "CodePipeline ID"
-  value       = coalesce(join("", aws_codepipeline.source_build.*.id), join("", aws_codepipeline.source_build_deploy.*.id))
+  value       = join("", aws_codepipeline.default.*.id)
 }
 
 output "codepipeline_arn" {
   description = "CodePipeline ARN"
-  value       = coalesce(join("", aws_codepipeline.source_build.*.arn), join("", aws_codepipeline.source_build_deploy.*.arn))
+  value       = join("", aws_codepipeline.default.*.arn)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -27,22 +27,16 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildProjectName := terraform.Output(t, terraformOptions, "codebuild_project_name")
-
-	expectedCodebuildProjectName := "eg-test-cicd-test-build"
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedCodebuildProjectName, codebuildProjectName)
+	assert.Equal(t, "eg-test-cicd-build", codebuildProjectName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildCacheS3BucketName := terraform.Output(t, terraformOptions, "codebuild_cache_bucket_name")
-
-	expectedCodebuildCacheS3BucketName := "eg-test-cicd-test-build"
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedCodebuildCacheS3BucketName, codebuildCacheS3BucketName)
+	assert.Equal(t, "eg-test-cicd-build", codebuildCacheS3BucketName)
 
 	// Run `terraform output` to get the value of an output variable
 	codepipelineId := terraform.Output(t, terraformOptions, "codepipeline_id")
-
-	expectedCodepipelineId := "eg-test-cicd-test"
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedCodepipelineId, codepipelineId)
+	assert.Equal(t, "eg-test-cicd", codepipelineId)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,7 @@ variable "elastic_beanstalk_environment_name" {
 variable "github_oauth_token" {
   type        = string
   description = "GitHub Oauth Token with permissions to access private repositories"
+  default     = ""
 }
 
 variable "repo_owner" {

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "privileged_mode" {
   description = "If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images"
 }
 
-variable "aws_region" {
+variable "region" {
   type        = string
   default     = ""
   description = "AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html)"

--- a/variables.tf
+++ b/variables.tf
@@ -21,13 +21,13 @@ variable "enabled" {
   description = "Enable ``CodePipeline`` creation"
 }
 
-variable "app" {
+variable "elastic_beanstalk_application_name" {
   type        = string
   default     = ""
   description = "Elastic Beanstalk application name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created"
 }
 
-variable "env" {
+variable "elastic_beanstalk_environment_name" {
   type        = string
   default     = ""
   description = "Elastic Beanstalk environment name. If not provided or set to empty string, the ``Deploy`` stage of the pipeline will not be created"

--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,9 @@ variable "codebuild_cache_bucket_suffix_enabled" {
   description = "The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value"
   default     = true
 }
+
+variable "force_destroy" {
+  type        = bool
+  default     = false
+  description = "Force destroy the CI/CD S3 bucket even if it's not empty"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -35,8 +35,7 @@ variable "elastic_beanstalk_environment_name" {
 
 variable "github_oauth_token" {
   type        = string
-  description = "GitHub Oauth Token with permissions to access private repositories"
-  default     = ""
+  description = "GitHub Oauth Token"
 }
 
 variable "repo_owner" {
@@ -102,7 +101,7 @@ variable "privileged_mode" {
   description = "If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images"
 }
 
-variable "region" {
+variable "aws_region" {
   type        = string
   default     = ""
   description = "AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html)"

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "privileged_mode" {
   description = "If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images"
 }
 
-variable "aws_region" {
+variable "region" {
   type        = string
   default     = ""
   description = "AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html)"


### PR DESCRIPTION
## what
* Fix counts
* Use dynamic block for Deploy stage
* Add `enabled` flag

## why
* Fix `count can't be computed` errors
* Using `dynamic` block for the Deploy stage allows having only one `aws_codepipeline` resource instead of relying on counts to enable/disable two resources
* Properly use `enabled` flag on all recources
