### PR TITLE
Fix TF 13 compatibility issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 module "codebuild" {
-  source                      = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.17.0"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.27.0"
   enabled                     = var.enabled
   namespace                   = var.namespace
   name                        = var.name

--- a/main.tf
+++ b/main.tf
@@ -169,6 +169,7 @@ module "codebuild" {
   github_token                = var.github_oauth_token
   environment_variables       = var.environment_variables
   cache_bucket_suffix_enabled = var.codebuild_cache_bucket_suffix_enabled
+  cache_type                  = var.codebuild_cache_type
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,13 @@ variable "codebuild_cache_bucket_suffix_enabled" {
   default     = true
 }
 
+variable "codebuild_cache_type" {
+  type        = string
+  description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3"
+  default     = "S3"
+}
+
+
 variable "force_destroy" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Change the pinned version of `terraform-aws-codebuild` to `0.27.0`
* Add a variable `codebuild_cache_type` (that defaults to S3) to keep this module backwards compatible with the previous pinned version (which was 0.17.0) which had default S3 cache defined.

## why
* Make this module TF 13 compatible. Version 0.17.0 of `terraform-aws-codebuild` was not TF 13 compatible.


