### PR TITLE
Terraform 0.14 upgrade

### DIFF
--- a/.build-harness
+++ b/.build-harness
@@ -94,7 +94,7 @@ tester/pull:
 build-harness/runner:
 	$(info Starting $(RUNNER_DOCKER_IMAGE):$(RUNNER_DOCKER_TAG))
 	docker run --name build-harness \
-		--rm \
+		--rm -it \
 		-e PACKAGES_PREFER_HOST=true \
 		$(addprefix -e ,$(DOCKER_ENVS)) \
 		$(MOUNT_HOME) \

--- a/.build-harness
+++ b/.build-harness
@@ -94,7 +94,7 @@ tester/pull:
 build-harness/runner:
 	$(info Starting $(RUNNER_DOCKER_IMAGE):$(RUNNER_DOCKER_TAG))
 	docker run --name build-harness \
-		--rm -it \
+		--rm \
 		-e PACKAGES_PREFER_HOST=true \
 		$(addprefix -e ,$(DOCKER_ENVS)) \
 		$(MOUNT_HOME) \

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 


### PR DESCRIPTION
## what
- Upgrade to support Terraform 0.14 and bring up to current Cloud Posse standard

## why
- Support Terraform 0.14
