### PR TITLE
readme updated, code cleaned, BC compliance checks fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Compiled files
 *.tfstate
 *.tfstate.backup
+**/.terraform.lock.hcl
 
 # Module directory
 .terraform

--- a/README.md
+++ b/README.md
@@ -257,10 +257,6 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| local | >= 1.2 |
-| null | >= 2.0 |
-| random | >= 2.1 |
-| template | >= 2.0 |
 
 ## Providers
 
@@ -272,6 +268,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_log\_bucket\_name | Name of the S3 bucket where s3 access log will be sent to | `string` | `""` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `""` | no |
@@ -294,6 +291,7 @@ Available targets:
 | image\_repo\_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"UNSET"` | no |
 | image\_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"latest"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | poll\_source\_changes | Periodically check the location of your source content and run the pipeline if changes are detected | `bool` | `true` | no |
@@ -302,8 +300,10 @@ Available targets:
 | region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `""` | no |
 | repo\_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | `string` | n/a | yes |
 | repo\_owner | GitHub Organization or Person name | `string` | n/a | yes |
+| s3\_bucket\_encryption\_enabled | When set to 'true' the 'aws\_s3\_bucket' resource will have AES256 encryption enabled by default | `bool` | `true` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| versioning\_enabled | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,10 +5,6 @@
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| local | >= 1.2 |
-| null | >= 2.0 |
-| random | >= 2.1 |
-| template | >= 2.0 |
 
 ## Providers
 
@@ -20,6 +16,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_log\_bucket\_name | Name of the S3 bucket where s3 access log will be sent to | `string` | `""` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | AWS Account ID. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `""` | no |
@@ -42,6 +39,7 @@
 | image\_repo\_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"UNSET"` | no |
 | image\_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"latest"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | poll\_source\_changes | Periodically check the location of your source content and run the pipeline if changes are detected | `bool` | `true` | no |
@@ -50,8 +48,10 @@
 | region | AWS Region, e.g. `us-east-1`. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `""` | no |
 | repo\_name | GitHub repository name of the application to be built (and deployed to Elastic Beanstalk if configured) | `string` | n/a | yes |
 | repo\_owner | GitHub Organization or Person name | `string` | n/a | yes |
+| s3\_bucket\_encryption\_enabled | When set to 'true' the 'aws\_s3\_bucket' resource will have AES256 encryption enabled by default | `bool` | `true` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| versioning\_enabled | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
 
 ## Outputs
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -37,3 +37,5 @@ environment_variables = [
 ]
 
 cache_type = "S3"
+
+mfa_delete = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,6 +14,7 @@ module "cicd" {
   codebuild_cache_bucket_suffix_enabled = var.codebuild_cache_bucket_suffix_enabled
   force_destroy                         = var.force_destroy
   cache_type                            = var.cache_type
+  mfa_delete                            = var.mfa_delete
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -58,3 +58,8 @@ variable "cache_type" {
   type        = string
   description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3.  Defaults to NO_CACHE.  If cache_type is S3, it will create an S3 bucket for storing codebuild cache inside"
 }
+
+variable "mfa_delete" {
+  type        = bool
+  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
+}

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_iam_role" "default" {
   count              = local.enabled ? 1 : 0
   name               = module.this.id
   assume_role_policy = join("", data.aws_iam_policy_document.assume.*.json)
+  tags               = module.this.tags
 }
 
 data "aws_iam_policy_document" "assume" {
@@ -217,6 +218,7 @@ resource "aws_codepipeline" "default" {
   count    = local.enabled ? 1 : 0
   name     = module.this.id
   role_arn = join("", aws_iam_role.default.*.arn)
+  tags     = module.this.tags
 
   artifact_store {
     location = join("", aws_s3_bucket.default.*.bucket)

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,39 @@ locals {
 }
 
 resource "aws_s3_bucket" "default" {
+  #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   count         = local.enabled ? 1 : 0
   bucket        = module.this.id
   acl           = "private"
   force_destroy = var.force_destroy
   tags          = module.this.tags
+
+  versioning {
+    enabled    = var.versioning_enabled
+    mfa_delete = var.mfa_delete
+  }
+
+  dynamic "logging" {
+    for_each = var.access_log_bucket_name != "" ? [1] : []
+    content {
+      target_bucket = var.access_log_bucket_name
+      target_prefix = "logs/${module.this.id}/"
+    }
+  }
+
+  dynamic "server_side_encryption_configuration" {
+    for_each = var.s3_bucket_encryption_enabled ? [1] : []
+
+    content {
+      rule {
+        apply_server_side_encryption_by_default {
+          sse_algorithm = "AES256"
+        }
+      }
+    }
+  }
+
 }
 
 resource "aws_iam_role" "default" {

--- a/test/src/go.mod
+++ b/test/src/go.mod
@@ -3,6 +3,6 @@ module github.com/cloudposse/terraform-aws-efs
 go 1.13
 
 require (
-	github.com/gruntwork-io/terratest v0.29.0
+	github.com/gruntwork-io/terratest v0.31.4
 	github.com/stretchr/testify v1.6.1
 )

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,27 @@ variable "cache_type" {
   default     = "S3"
   description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3.  Defaults to S3 to keep same behavior as before upgrading `codebuild` module to 0.18+ version.  If cache_type is S3, it will create an S3 bucket for storing codebuild cache inside"
 }
+
+variable "access_log_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Name of the S3 bucket where s3 access log will be sent to"
+}
+
+variable "s3_bucket_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "When set to 'true' the 'aws_s3_bucket' resource will have AES256 encryption enabled by default"
+}
+
+variable "versioning_enabled" {
+  type        = bool
+  default     = true
+  description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket"
+}
+
+variable "mfa_delete" {
+  type        = bool
+  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,21 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.1"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* BridgeCrew compliance checks fix
* readme updated
* code clean up 
* default behaviour changed: `S3 bucket MFA delete` enabled by default
* default behaviour changed: `S3 Bucket Versioning` enabled by default
* default behaviour changed: `Encryption of the S3 bucket` enabled by default

## why
* To be able to position our modules as standards compliant
* stay in sync with code
* removed unnecessary providers dependencies
* To comply BridgeCrew check

## references
* closes #77 
* https://docs.bridgecrew.io/docs/s3_16-enable-versioning
* https://docs.bridgecrew.io/docs/s3_13-enable-logging
* https://docs.bridgecrew.io/docs/s3_14-data-encrypted-at-rest
