### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,14 @@
 {
   "extends": [
     "config:base",
-    ":preserveSemverRanges"
+    ":preserveSemverRanges",
+    ":rebaseStalePrs"
   ],
-  "baseBranches": ["main", "master", "/^release\\/v\\d{1,2}$/"],
+  "baseBranches": ["main"],
   "labels": ["auto-update"],
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
-    "ignorePaths": ["**/context.tf", "examples/**"]
+    "ignorePaths": ["**/context.tf"]
   }
 }

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | cloudposse/codebuild/aws | 1.0.0 |
+| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | cloudposse/codebuild/aws | 2.0.1 |
 | <a name="module_github_webhook"></a> [github\_webhook](#module\_github\_webhook) | cloudposse/repository-webhooks/github | 0.12.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ To activate this mode, don't specify the ``app`` and ``env`` attributes for the 
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-[<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
-[<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
-[<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
-[<img align="right" title="Share on Reddit" src="https://docs.cloudposse.com/images/ionicons/social-reddit-outline-2.0.1-16x16-999999.svg" />][share_reddit]
-[<img align="right" title="Share on LinkedIn" src="https://docs.cloudposse.com/images/ionicons/social-linkedin-outline-2.0.1-16x16-999999.svg" />][share_linkedin]
-[<img align="right" title="Share on Twitter" src="https://docs.cloudposse.com/images/ionicons/social-twitter-outline-2.0.1-16x16-999999.svg" />][share_twitter]
 
 
 [![Terraform Open Source Modules](https://docs.cloudposse.com/images/terraform-open-source-modules.svg)][terraform_modules]
@@ -109,10 +103,6 @@ difficulty of keeping the versions in the documentation in sync with the latest 
 We highly recommend that in your code you pin the version to the exact version you are
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
-
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
 
 
 Include this repository as a module in your existing terraform code:
@@ -390,8 +380,6 @@ Available targets:
 
 Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-cicd)! (it helps us **a lot**)
 
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
-
 
 
 ## Related Projects
@@ -433,10 +421,6 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
@@ -447,7 +431,18 @@ Sign up for [our newsletter][newsletter] that covers everything on our technolog
 
 [![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
 
-## Contributing
+## ✨ Contributing
+
+
+
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
+
+<a href="https://github.com/cloudposse/terraform-aws-cicd/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/terraform-aws-cicd&max=24" />
+</a>
+
+
 
 ### Bug Reports & Feature Requests
 
@@ -521,27 +516,7 @@ We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. W
 
 We offer [paid support][commercial_support] on all of our projects.
 
-Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
-
-
-
-### Contributors
-
-<!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
-|---|---|---|---|
-<!-- markdownlint-restore -->
-
-  [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
-  [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
-  [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
-  [nitrocode_homepage]: https://github.com/nitrocode
-  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
-
-[![README Footer][readme_footer_img]][readme_footer_link]
+Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.[![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
 <!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
@@ -551,12 +526,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=jobs
   [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=hire
   [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=linkedin
   [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=twitter
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=we_love_open_source
@@ -567,11 +540,5 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
   [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cicd&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-aws-cicd&url=https://github.com/cloudposse/terraform-aws-cicd
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-aws-cicd&url=https://github.com/cloudposse/terraform-aws-cicd
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-aws-cicd
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-aws-cicd
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-cicd
-  [share_email]: mailto:?subject=terraform-aws-cicd&body=https://github.com/cloudposse/terraform-aws-cicd
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-cicd?pixel&cs=github&cm=readme&an=terraform-aws-cicd
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -272,15 +272,15 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 
 ## Modules

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | cloudposse/codebuild/aws | 1.0.0 |
+| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | cloudposse/codebuild/aws | 2.0.1 |
 | <a name="module_github_webhook"></a> [github\_webhook](#module\_github\_webhook) | cloudposse/repository-webhooks/github | 0.12.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,15 +3,15 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 
 ## Modules

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ locals {
   enabled         = module.this.enabled
   webhook_enabled = local.enabled && var.webhook_enabled ? true : false
   webhook_count   = local.webhook_enabled ? 1 : 0
-  webhook_secret  = join("", random_password.webhook_secret.*.result)
-  webhook_url     = join("", aws_codepipeline_webhook.default.*.url)
+  webhook_secret  = join("", random_password.webhook_secret[*].result)
+  webhook_url     = join("", aws_codepipeline_webhook.default[*].url)
 }
 
 resource "aws_s3_bucket" "default" {
@@ -51,7 +51,7 @@ resource "aws_s3_bucket" "default" {
 resource "aws_iam_role" "default" {
   count              = local.enabled ? 1 : 0
   name               = module.this.id
-  assume_role_policy = join("", data.aws_iam_policy_document.assume.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.assume[*].json)
   tags               = module.this.tags
 }
 
@@ -76,14 +76,14 @@ data "aws_iam_policy_document" "assume" {
 
 resource "aws_iam_role_policy_attachment" "default" {
   count      = local.enabled ? 1 : 0
-  role       = join("", aws_iam_role.default.*.id)
-  policy_arn = join("", aws_iam_policy.default.*.arn)
+  role       = join("", aws_iam_role.default[*].id)
+  policy_arn = join("", aws_iam_policy.default[*].arn)
 }
 
 resource "aws_iam_policy" "default" {
   count  = local.enabled ? 1 : 0
   name   = module.this.id
-  policy = join("", data.aws_iam_policy_document.default.*.json)
+  policy = join("", data.aws_iam_policy_document.default[*].json)
 }
 
 data "aws_iam_policy_document" "default" {
@@ -115,14 +115,14 @@ data "aws_iam_policy_document" "default" {
 
 resource "aws_iam_role_policy_attachment" "s3" {
   count      = local.enabled ? 1 : 0
-  role       = join("", aws_iam_role.default.*.id)
-  policy_arn = join("", aws_iam_policy.s3.*.arn)
+  role       = join("", aws_iam_role.default[*].id)
+  policy_arn = join("", aws_iam_policy.s3[*].arn)
 }
 
 resource "aws_iam_policy" "s3" {
   count  = local.enabled ? 1 : 0
   name   = "${module.this.id}-s3"
-  policy = join("", data.aws_iam_policy_document.s3.*.json)
+  policy = join("", data.aws_iam_policy_document.s3[*].json)
 }
 
 data "aws_s3_bucket" "website" {
@@ -144,8 +144,8 @@ data "aws_iam_policy_document" "s3" {
     ]
 
     resources = [
-      join("", aws_s3_bucket.default.*.arn),
-      "${join("", aws_s3_bucket.default.*.arn)}/*",
+      join("", aws_s3_bucket.default[*].arn),
+      "${join("", aws_s3_bucket.default[*].arn)}/*",
       "arn:aws:s3:::elasticbeanstalk*"
     ]
 
@@ -166,8 +166,8 @@ data "aws_iam_policy_document" "s3" {
       ]
 
       resources = [
-        join("", data.aws_s3_bucket.website.*.arn),
-        "${join("", data.aws_s3_bucket.website.*.arn)}/*"
+        join("", data.aws_s3_bucket.website[*].arn),
+        "${join("", data.aws_s3_bucket.website[*].arn)}/*"
       ]
 
       effect = "Allow"
@@ -177,14 +177,14 @@ data "aws_iam_policy_document" "s3" {
 
 resource "aws_iam_role_policy_attachment" "codebuild" {
   count      = local.enabled ? 1 : 0
-  role       = join("", aws_iam_role.default.*.id)
-  policy_arn = join("", aws_iam_policy.codebuild.*.arn)
+  role       = join("", aws_iam_role.default[*].id)
+  policy_arn = join("", aws_iam_policy.codebuild[*].arn)
 }
 
 resource "aws_iam_policy" "codebuild" {
   count  = local.enabled ? 1 : 0
   name   = "${module.this.id}-codebuild"
-  policy = join("", data.aws_iam_policy_document.codebuild.*.json)
+  policy = join("", data.aws_iam_policy_document.codebuild[*].json)
 }
 
 data "aws_iam_policy_document" "codebuild" {
@@ -226,7 +226,7 @@ module "codebuild" {
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {
   count      = local.enabled ? 1 : 0
   role       = module.codebuild.role_id
-  policy_arn = join("", aws_iam_policy.s3.*.arn)
+  policy_arn = join("", aws_iam_policy.s3[*].arn)
 }
 
 # Only one of the `aws_codepipeline` resources below will be created:
@@ -249,11 +249,11 @@ resource "aws_codepipeline" "default" {
   # Elastic Beanstalk application name and environment name are specified
   count    = local.enabled ? 1 : 0
   name     = module.this.id
-  role_arn = join("", aws_iam_role.default.*.arn)
+  role_arn = join("", aws_iam_role.default[*].arn)
   tags     = module.this.tags
 
   artifact_store {
-    location = join("", aws_s3_bucket.default.*.bucket)
+    location = join("", aws_s3_bucket.default[*].bucket)
     type     = "S3"
   }
 
@@ -354,7 +354,7 @@ resource "aws_codepipeline_webhook" "default" {
   name            = module.this.id
   authentication  = var.webhook_authentication
   target_action   = var.webhook_target_action
-  target_pipeline = join("", aws_codepipeline.default.*.name)
+  target_pipeline = join("", aws_codepipeline.default[*].name)
 
   authentication_configuration {
     secret_token = local.webhook_secret

--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ data "aws_iam_policy_document" "codebuild" {
 
 module "codebuild" {
   source                      = "cloudposse/codebuild/aws"
-  version                     = "1.0.0"
+  version                     = "2.0.1"
   build_image                 = var.build_image
   build_compute_type          = var.build_compute_type
   buildspec                   = var.buildspec

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,10 +35,10 @@ output "codebuild_badge_url" {
 
 output "codepipeline_id" {
   description = "CodePipeline ID"
-  value       = join("", aws_codepipeline.default.*.id)
+  value       = join("", aws_codepipeline.default[*].id)
 }
 
 output "codepipeline_arn" {
   description = "CodePipeline ARN"
-  value       = join("", aws_codepipeline.default.*.arn)
+  value       = join("", aws_codepipeline.default[*].arn)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## what

Support AWS Provider V5
Major release because of the dependencies pinning aws provider v5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
